### PR TITLE
fix: 修复未正确挂载新节点的问题

### DIFF
--- a/course5-渲染器/code-11.1.html
+++ b/course5-渲染器/code-11.1.html
@@ -144,26 +144,26 @@ function createRenderer(options) {
         }
       }
 
-      if (moved) {
-        const seq = lis(source)
-        // s 指向最长递增子序列的最后一个值
-        let s = seq.length - 1
-        let i = count - 1
-        for (i; i >= 0; i--) {
-          if (source[i] === -1) {
-            // 说明索引为 i 的节点是全新的节点，应该将其挂载
-            // 该节点在新 children 中的真实位置索引
-            const pos = i + newStart
-            const newVNode = newChildren[pos]
-            // 该节点下一个节点的位置索引
-            const nextPos = pos + 1
-            // 锚点
-            const anchor = nextPos < newChildren.length
-              ? newChildren[nextPos].el
-              : null
-            // 挂载
-            patch(null, newVNode, container, anchor)
-          } else if (i !== seq[j]) {
+      const seq = lis(source)
+      // s 指向最长递增子序列的最后一个值
+      let s = seq.length - 1
+      let i = count - 1
+      for (i; i >= 0; i--) {
+        if (source[i] === -1) {
+          // 说明索引为 i 的节点是全新的节点，应该将其挂载
+          // 该节点在新 children 中的真实位置索引
+          const pos = i + newStart
+          const newVNode = newChildren[pos]
+          // 该节点下一个节点的位置索引
+          const nextPos = pos + 1
+          // 锚点
+          const anchor = nextPos < newChildren.length
+            ? newChildren[nextPos].el
+            : null
+          // 挂载
+          patch(null, newVNode, container, anchor)
+        } else if (moved) {
+          if (i !== seq[j]) {
             // 说明该节点需要移动
             // 该节点在新的一组子节点中的真实位置索引
             const pos = i + newStart
@@ -184,7 +184,6 @@ function createRenderer(options) {
         }
       }
     }
-
   }
 
   function patchElement(n1, n2) {


### PR DESCRIPTION
根据目前的实现，假设前置节点和后置节点都处理完，各只剩一个节点，分别是一个新增节点和一个删除节点，那么此时新增的节点不会被挂载。
```js
// 此时节点 5 会被忽略
const prev = [1, 2, 3, 4]
const next = [1, 2, 5, 4]
```
将 moved 判断移入循环中使得 source 数组中 -1 的元素得以挂载。